### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.0 - 2019-03-31
+
+### Changed
+
+- JSON header is included for error responses.
+- 500 error now responds with a JSON string.
+
 ## 1.1.1 - 2019-03-08
 
 ### Added

--- a/src/api/response.go
+++ b/src/api/response.go
@@ -55,7 +55,12 @@ func HandleErrorResponse(err error, msg string, code int) (Response, error) {
 		resp := Response{
 			IsBase64Encoded: true,
 			StatusCode:      500,
-			Body:            "failed to marshal error response",
+			Body:            `{"error": "failed to marshal error response on server"}`,
+			Headers: map[string]string{
+				"Content-Type":                     "application/json",
+				"Access-Control-Allow-Origin":      "*",
+				"Access-Control-Allow-Credentials": "true",
+			},
 		}
 		return resp, nil
 	}
@@ -64,6 +69,11 @@ func HandleErrorResponse(err error, msg string, code int) (Response, error) {
 		IsBase64Encoded: true,
 		StatusCode:      code,
 		Body:            string(jsonErrResp),
+		Headers: map[string]string{
+			"Content-Type":                     "application/json",
+			"Access-Control-Allow-Origin":      "*",
+			"Access-Control-Allow-Credentials": "true",
+		},
 	}
 	return resp, nil
 }


### PR DESCRIPTION
### Changed

- JSON header is included for error responses.
- 500 error now responds with a JSON string.